### PR TITLE
header.php - bug fix javascript error href attr #

### DIFF
--- a/common/header.php
+++ b/common/header.php
@@ -59,7 +59,7 @@
                 <ul class="nav nav-pills pull-right">
 
                     <?php if ($scripto->isLoggedIn()): ?>
-                    <li class="dropdown"><a href="#" class="dropdown-toggle" data-toggle="dropdown"><strong><?php echo $scripto->getUserName(); ?></strong><b class="caret"></b></a>
+                    <li class="dropdown"><a href="menu" class="dropdown-toggle" data-toggle="dropdown"><strong><?php echo $scripto->getUserName(); ?></strong><b class="caret"></b></a>
                         <ul class="dropdown-menu">
                             <li><a href="<?php echo WEB_ROOT; ?>/scripto">Your Contributions</a></li>
                             <li><a href="<?php echo WEB_ROOT; ?>/scripto/watchlist">Your Watchlist</a></li>


### PR DESCRIPTION
In Console: Uncaught Error: Syntax error, unrecognized expression: #
Since bootstrap.js uses the href attr for the selector and # is an invalid javascript selector, I changed the href attr value to "menu". It doesn't matter what it is as long as it's a valid JavaScript selector, since the link's default behavior is prevented.